### PR TITLE
Support Multiple HID devices in parallel

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -317,6 +317,8 @@ include_directories(cryptoauth PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
                                       ../third_party/hidapi/hidapi 
                                       ${USB_INCLUDE_DIR})
 
+include(${CMAKE_CURRENT_LIST_DIR}/../toolkit/toolkit.cmake)
+
 if(ATCA_MBEDTLS)
 target_link_libraries(cryptoauth mbedtls)
 endif()

--- a/lib/atca_cfgs.c
+++ b/lib/atca_cfgs.c
@@ -101,6 +101,7 @@ ATCAIfaceCfg cfg_ateccx08a_kithid_default = {
         .atcahid.vid             = 0x03EB,
         .atcahid.pid             = 0x2312,
         .atcahid.packetsize      = 64,
+        .atcahid.path            = NULL
     }
 };
 #endif
@@ -169,6 +170,7 @@ ATCAIfaceCfg cfg_atsha20xa_kithid_default = {
         .atcahid.vid           = 0x03EB,
         .atcahid.pid           = 0x2312,
         .atcahid.packetsize    = 64,
+        .atcahid.path          = NULL
     },
     .rx_retries                = 1
 };

--- a/lib/atca_iface.h
+++ b/lib/atca_iface.h
@@ -150,9 +150,10 @@ typedef struct
             int         idx;           // HID enumeration index
             ATCAKitType dev_interface; // Kit interface type
             uint8_t     dev_identity;  // I2C address for the I2C interface device or the bus number for the SWI interface device.
-            uint32_t    vid;           // Vendor ID of kit (0x03EB for CK101)
-            uint32_t    pid;           // Product ID of kit (0x2312 for CK101)
+            uint16_t    vid;           // Vendor ID of kit (0x03EB for CK101)
+            uint16_t    pid;           // Product ID of kit (0x2312 for CK101)
             uint32_t    packetsize;    // Size of the USB packet
+            const char* path;          // Device path
         } atcahid;
 
         struct

--- a/lib/hal/hal_all_platforms_kit_hidapi.c
+++ b/lib/hal/hal_all_platforms_kit_hidapi.c
@@ -59,7 +59,14 @@ ATCA_STATUS hal_kit_hid_init(ATCAIface iface, ATCAIfaceCfg* cfg)
 #endif
     (void)hid_init();
 
-    iface->hal_data = hid_open((uint16_t)(ATCA_IFACECFG_VALUE(cfg, atcahid.vid) & UINT16_MAX), (uint16_t)(ATCA_IFACECFG_VALUE(cfg, atcahid.pid) & UINT16_MAX), NULL);
+    if (ATCA_IFACECFG_VALUE(cfg, atcahid.path) == NULL)
+    {
+        iface->hal_data = hid_open((uint16_t)(ATCA_IFACECFG_VALUE(cfg, atcahid.vid) & UINT16_MAX), (uint16_t)(ATCA_IFACECFG_VALUE(cfg, atcahid.pid) & UINT16_MAX), NULL);
+    }
+    else
+    {
+        iface->hal_data = hid_open_path(ATCA_IFACECFG_VALUE(cfg, atcahid.path));
+    }
 
     return (NULL != iface->hal_data) ? ATCA_SUCCESS : ATCA_COMM_FAIL;
 }

--- a/toolkit/Toolkit.cmake
+++ b/toolkit/Toolkit.cmake
@@ -1,0 +1,41 @@
+# Toolkit.cmake
+#
+# 2023
+
+include_guard()
+
+# Options
+option(TOOLKIT_ENABLED "Enable toolkit which extends CryptoAuth library" OFF)
+
+if (NOT TOOLKIT_ENABLED)
+    return()
+endif()
+
+target_include_directories(cryptoauth
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/include
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/src
+)
+
+target_sources(cryptoauth
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/src/toolkit/tk_api_log_int.c
+        ${CMAKE_CURRENT_LIST_DIR}/src/toolkit/tk_atca_hid_device_factory.c
+)
+
+if (WIN32)
+    target_sources(cryptoauth
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/src/toolkit/windows/tk_ctp_board.c
+    )
+
+    target_link_libraries(cryptoauth cfgmgr32.lib)
+else()
+    message(WARNING "Enumeration of CryptoAuth Trust Platform boards currently supported only on \{ WIN32 \} platform(s) !")
+endif()
+
+if (DEFAULT_INC_PATH)
+    file(GLOB TOOLKIT_INC RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "include/toolkit/*.h")
+    install(FILES ${TOOLKIT_INC} DESTINATION ${DEFAULT_INC_PATH}/toolkit COMPONENT Development)
+endif()

--- a/toolkit/include/toolkit/tk_api_export.h
+++ b/toolkit/include/toolkit/tk_api_export.h
@@ -1,0 +1,16 @@
+/// @file tk_api_export.h
+///
+/// 2023
+
+#ifndef CRYPTOAUTHLIB_TOOLKIT_API_EXPORT_H
+#define CRYPTOAUTHLIB_TOOLKIT_API_EXPORT_H
+
+#ifdef _WIN32
+      #define TK_API_EXPORT __declspec(dllexport)
+      #define TK_API_CALL
+#else
+      #define TK_API_EXPORT /**< API export macro */
+      #define TK_API_CALL /**< API call macro */
+#endif
+
+#endif

--- a/toolkit/include/toolkit/tk_api_log.h
+++ b/toolkit/include/toolkit/tk_api_log.h
@@ -1,0 +1,24 @@
+/// @file tk_api_log.h
+///
+/// 2023
+
+#ifndef CRYPTOAUTHLIB_TOOLKIT_API_LOG_H
+#define CRYPTOAUTHLIB_TOOLKIT_API_LOG_H
+
+#include "toolkit/tk_api_export.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+/// Get last error that was encountered by Toolkit.
+const char TK_API_EXPORT * TK_API_CALL tk_api_log_get_last_error(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/toolkit/include/toolkit/tk_atca_hid_device_factory.h
+++ b/toolkit/include/toolkit/tk_atca_hid_device_factory.h
@@ -1,0 +1,28 @@
+/// @file tk_atca_hid_device_factory.h
+///
+/// 2023
+
+#ifndef CRYPTOAUTHLIB_TOOLKIT_ATCA_HID_DEVICE_FACTORY_H
+#define CRYPTOAUTHLIB_TOOLKIT_ATCA_HID_DEVICE_FACTORY_H
+
+#include "toolkit/tk_api_export.h"
+#include "atca_device.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+/// Create ATCA device instance based on device path.
+ATCADevice TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_create(const char* path, const char* device_type);
+
+/// Destroy previously created device.
+void TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_destroy(ATCADevice dev);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/toolkit/include/toolkit/tk_ctp_board.h
+++ b/toolkit/include/toolkit/tk_ctp_board.h
@@ -1,0 +1,77 @@
+/// @file tk_ctp_board.h
+///
+/// 2023
+
+#ifndef CRYPTOAUTHLIB_TOOLKIT_CTP_BOARD_H
+#define CRYPTOAUTHLIB_TOOLKIT_CTP_BOARD_H
+
+#include <stddef.h>
+
+#include "toolkit/tk_api_export.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+/// Vendor ID of nEDBG embedded on CryptoAuth Trust Platform board.
+#define TK_CTP_BOARD_NEDBG_VID 0x03EB
+
+/// Product ID of nEDBG embedded on CryptoAuth Trust Platform board.
+#define TK_CTP_BOARD_NEDBG_PID 0x2175
+
+/// Vendor ID of Host MCU embedded on CryptoAuth Trust Platform board.
+#define TK_CTP_BOARD_HOST_MCU_VID 0x03EB
+
+/// Product ID of Host MCU embedded on CryptoAuth Trust Platform board.
+#define TK_CTP_BOARD_HOST_MCU_PID 0x2312
+
+/// Vendor ID of USB HUB embedded on CryptoAuth Trust Platform board.
+#define TK_CTP_BOARD_HUB_VID 0x0424
+
+/// Product ID of USB HUB embedded on CryptoAuth Trust Platform board.
+#define TK_CTP_BOARD_HUB_PID 0x2422
+
+
+/// CryptoAuth Trust Platform board info.
+struct tk_ctp_board_info
+{
+    // Serial Number of nEDBG embedded on board.
+    wchar_t* nedbg_serial_number;
+
+    // Path to nEDBG embedded on board.
+    char* nedbg_path;
+
+    // Path to Host MCU embedded on board.
+    char* host_mcu_path;
+
+    // Pointer to the next board info.
+    struct tk_ctp_board_info* next;
+};
+
+
+/// Enumerate CryptoAuth Trust Platform boards attached to the host PC via USB.
+struct tk_ctp_board_info TK_API_EXPORT * TK_API_CALL tk_ctp_board_enumerate(void);
+
+/// Get next board info.
+struct tk_ctp_board_info TK_API_EXPORT * TK_API_CALL tk_ctp_board_next_board(struct tk_ctp_board_info* boards);
+
+/// Free resources allocated for boards enumeration.
+void TK_API_EXPORT TK_API_CALL tk_ctp_board_free_enumeration(struct tk_ctp_board_info* boards);
+
+/// Get Serial Number of nEDBG from board info.
+const wchar_t TK_API_EXPORT * TK_API_CALL tk_ctp_board_get_nedbg_serial_number(struct tk_ctp_board_info* board);
+
+/// Get Path of nEDBG from board info.
+const char TK_API_EXPORT * TK_API_CALL tk_ctp_board_get_nedbg_path(struct tk_ctp_board_info* board);
+
+/// Get Path of Host MCU from board info.
+const char TK_API_EXPORT * TK_API_CALL tk_ctp_board_get_host_mcu_path(struct tk_ctp_board_info* board);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/toolkit/src/toolkit/tk_api_log_int.c
+++ b/toolkit/src/toolkit/tk_api_log_int.c
@@ -1,0 +1,43 @@
+/// @file tk_api_log_int.d
+///
+/// 2023
+
+#include <string.h>
+#include <stdarg.h>
+
+#include "tk_api_log_int.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#define TK_API_LOG_INT_LAST_ERROR_MAX_LEN 1024U
+static char f_tk_api_log_int_last_error_buffer[TK_API_LOG_INT_LAST_ERROR_MAX_LEN + 1U];
+
+const char TK_API_EXPORT * TK_API_CALL tk_api_log_get_last_error(void)
+{
+    return f_tk_api_log_int_last_error_buffer;
+}
+
+void tk_api_log_int_clear(void)
+{
+    (void)memset(f_tk_api_log_int_last_error_buffer, 0, sizeof(f_tk_api_log_int_last_error_buffer));
+}
+
+void tk_api_log_int_error(const char* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+
+    (void)vsnprintf(f_tk_api_log_int_last_error_buffer, TK_API_LOG_INT_LAST_ERROR_MAX_LEN, fmt, args);
+    f_tk_api_log_int_last_error_buffer[TK_API_LOG_INT_LAST_ERROR_MAX_LEN] = '\0';
+
+    va_end(args);
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/toolkit/src/toolkit/tk_api_log_int.h
+++ b/toolkit/src/toolkit/tk_api_log_int.h
@@ -1,0 +1,27 @@
+/// @file tk_api_log_int.h
+///
+/// 2023
+
+#ifndef CRYPTOAUTHLIB_TOOLKIT_API_LOG_INT_H
+#define CRYPTOAUTHLIB_TOOLKIT_API_LOG_INT_H
+
+#include "toolkit/tk_api_log.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+/// Get last error that was encountered by Toolkit.
+void tk_api_log_int_clear(void);
+
+/// Log error.
+void tk_api_log_int_error(const char* fmt, ...);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/toolkit/src/toolkit/tk_atca_hid_device_factory.c
+++ b/toolkit/src/toolkit/tk_atca_hid_device_factory.c
@@ -1,0 +1,100 @@
+/// @file tk_atca_hid_device_factory.c
+///
+/// 2023
+
+#include "toolkit/tk_atca_hid_device_factory.h"
+#include "toolkit/tk_api_log_int.h"
+#include "atca_basic.h"
+#include "atca_iface.h"
+#include "atca_cfgs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+ATCADevice TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_create(const char* path, const char* device_type)
+{
+    tk_api_log_int_clear();
+
+    char* path_copy = NULL;
+    ATCAIfaceCfg* iface_cfg = NULL;
+    ATCADevice dev = NULL;
+    ATCADeviceType dev_type = iface_get_device_type_by_name(device_type);
+
+    if (dev_type == ATCA_DEV_INVALID || dev_type == ATCA_DEV_UNKNOWN)
+    {
+        tk_api_log_int_error("tk_atca_hid_device_factory_create: Unknown dev type: %s", device_type == NULL ? "Null" : device_type);
+        goto error;
+    }
+
+    size_t path_len = strlen(path);
+    path_copy = (char*)calloc(path_len, sizeof(path[0U]));
+
+    if (path_copy == NULL)
+    {
+        tk_api_log_int_error("tk_atca_hid_device_factory_create: Calloc of path buffer failed, path len: %d", path_len);
+        goto error;
+    }
+
+    iface_cfg = (ATCAIfaceCfg*)malloc(sizeof(ATCAIfaceCfg));
+
+    if (iface_cfg == NULL)
+    {
+        tk_api_log_int_error("tk_atca_hid_device_factory_create: Malloc of iface cfg failed");
+        goto error;
+    }
+
+    (void)memcpy(path_copy, path, path_len);
+    path_copy[path_len] = '\0';
+
+    // Default values from the example.
+    // See: cfg_atsha20xa_kithid_default
+    iface_cfg->iface_type            = ATCA_HID_IFACE;
+    iface_cfg->devtype               = dev_type;
+    iface_cfg->rx_retries            = 1;
+    iface_cfg->atcahid.dev_interface = ATCA_KIT_AUTO_IFACE;
+    iface_cfg->atcahid.dev_identity  = 0;
+    iface_cfg->atcahid.idx           = 0;
+    iface_cfg->atcahid.vid           = 0; // vid and
+    iface_cfg->atcahid.pid           = 0; // pid are not needed as we use exact path
+    iface_cfg->atcahid.packetsize    = 64;
+    iface_cfg->atcahid.path          = path_copy;
+
+    ATCA_STATUS init_status = atcab_init_ext(&dev, &cfg_atsha20xa_kithid_default);
+
+    if (init_status != ATCA_SUCCESS)
+    {
+        tk_api_log_int_error("tk_atca_hid_device_factory_create: init failed with %d", init_status);
+        goto error;
+    }
+
+    return dev;
+
+error:
+    free(path_copy);
+    free(iface_cfg);
+    atcab_release_ext(&dev);
+    return NULL;
+}
+
+void TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_destroy(ATCADevice dev)
+{
+    if (dev != NULL && dev->mIface.mIfaceCFG != NULL)
+    {
+        if (dev->mIface.mIfaceCFG->atcahid.path != NULL)
+        {
+            free(dev->mIface.mIfaceCFG->atcahid.path);
+        }
+
+        free(dev->mIface.mIfaceCFG);
+    }
+
+    atcab_release_ext(&dev);
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/toolkit/src/toolkit/tk_atca_hid_device_factory.c
+++ b/toolkit/src/toolkit/tk_atca_hid_device_factory.c
@@ -85,7 +85,7 @@ void TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_destroy(ATCADevice dev
     {
         if (dev->mIface.mIfaceCFG->atcahid.path != NULL)
         {
-            hal_free(dev->mIface.mIfaceCFG->atcahid.path);
+            hal_free((char*)dev->mIface.mIfaceCFG->atcahid.path);
         }
 
         hal_free(dev->mIface.mIfaceCFG);

--- a/toolkit/src/toolkit/tk_atca_hid_device_factory.c
+++ b/toolkit/src/toolkit/tk_atca_hid_device_factory.c
@@ -62,7 +62,7 @@ ATCADevice TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_create(const cha
     iface_cfg->atcahid.packetsize    = 64;
     iface_cfg->atcahid.path          = path_copy;
 
-    ATCA_STATUS init_status = atcab_init_ext(&dev, &cfg_atsha20xa_kithid_default);
+    ATCA_STATUS init_status = atcab_init_ext(&dev, iface_cfg);
 
     if (init_status != ATCA_SUCCESS)
     {

--- a/toolkit/src/toolkit/tk_atca_hid_device_factory.c
+++ b/toolkit/src/toolkit/tk_atca_hid_device_factory.c
@@ -30,7 +30,7 @@ ATCADevice TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_create(const cha
     }
 
     size_t path_len = strlen(path);
-    path_copy = (char*)calloc(path_len, sizeof(path[0U]));
+    path_copy = (char*)hal_malloc(path_len + 1U);
 
     if (path_copy == NULL)
     {
@@ -38,7 +38,7 @@ ATCADevice TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_create(const cha
         goto error;
     }
 
-    iface_cfg = (ATCAIfaceCfg*)malloc(sizeof(ATCAIfaceCfg));
+    iface_cfg = (ATCAIfaceCfg*)hal_malloc(sizeof(ATCAIfaceCfg));
 
     if (iface_cfg == NULL)
     {
@@ -73,8 +73,8 @@ ATCADevice TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_create(const cha
     return dev;
 
 error:
-    free(path_copy);
-    free(iface_cfg);
+    hal_free(path_copy);
+    hal_free(iface_cfg);
     atcab_release_ext(&dev);
     return NULL;
 }
@@ -85,10 +85,10 @@ void TK_API_EXPORT TK_API_CALL tk_atca_hid_device_factory_destroy(ATCADevice dev
     {
         if (dev->mIface.mIfaceCFG->atcahid.path != NULL)
         {
-            free(dev->mIface.mIfaceCFG->atcahid.path);
+            hal_free(dev->mIface.mIfaceCFG->atcahid.path);
         }
 
-        free(dev->mIface.mIfaceCFG);
+        hal_free(dev->mIface.mIfaceCFG);
     }
 
     atcab_release_ext(&dev);

--- a/toolkit/src/toolkit/windows/tk_ctp_board.c
+++ b/toolkit/src/toolkit/windows/tk_ctp_board.c
@@ -1,0 +1,426 @@
+/// @file tk_ctp_board.c
+///
+/// 2023
+
+#include <string.h>
+#include <stdbool.h>
+#include <windows.h>
+#include <cfgmgr32.h>
+#include <initguid.h>
+#include <devpkey.h>
+#include <propkey.h>
+
+#include "hidapi.h"
+#include "toolkit/tk_ctp_board.h"
+#include "toolkit/tk_api_log_int.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+static wchar_t* tk_ctp_board_int_str_to_wstr(const char* str);
+static void* tk_ctp_board_int_hid_get_device_interface_property(const char* interface_path, const DEVPROPKEY* property_key, DEVPROPTYPE expected_property_type);
+static void* tk_ctp_board_int_hid_get_devnode_property(DEVINST dev_node, const DEVPROPKEY* property_key, DEVPROPTYPE expected_property_type);
+static bool tk_ctp_board_int_hid_locate_dev_node(DEVINST* dev_node, const char* interface_path);
+static bool tk_ctp_board_int_hid_locate_parent_dev_node(DEVINST* parent_dev_node, DEVINST dev_node, unsigned short vendor_id, unsigned short product_id);
+static bool tk_ctp_board_int_hid_locate_parent_dev_node_by_dev_path(DEVINST* parent_dev_node, const char* interface_path, unsigned short vendor_id, unsigned short product_id);
+
+
+struct tk_ctp_board_info TK_API_EXPORT* TK_API_CALL tk_ctp_board_enumerate(void)
+{
+    tk_api_log_int_clear();
+
+    struct tk_ctp_board_info* boards = NULL;
+    struct tk_ctp_board_info** boards_ite = &boards;
+    struct hid_device_info* nedbg_devs = hid_enumerate(TK_CTP_BOARD_NEDBG_VID, TK_CTP_BOARD_NEDBG_PID);
+    struct hid_device_info* host_mcu_devs = hid_enumerate(TK_CTP_BOARD_HOST_MCU_VID, TK_CTP_BOARD_HOST_MCU_PID);
+
+    for (struct hid_device_info* nedbg_ite = nedbg_devs; nedbg_ite != NULL; nedbg_ite = nedbg_ite->next)
+    {
+        if (nedbg_ite->path == NULL)
+        {
+            tk_api_log_int_error("tk_ctp_board_enumerate: nEDBG path missing");
+            continue;
+        }
+
+        if (nedbg_ite->serial_number == NULL)
+        {
+            tk_api_log_int_error("tk_ctp_board_enumerate: serial number missing for nEDBG: %s", nedbg_ite->path);
+            continue;
+        }
+
+        DEVINST nedbg_parent_node;
+        bool result = tk_ctp_board_int_hid_locate_parent_dev_node_by_dev_path(&nedbg_parent_node, nedbg_ite->path, TK_CTP_BOARD_HUB_VID, TK_CTP_BOARD_HUB_PID);
+
+        if (!result)
+        {
+            continue;
+        }
+
+        struct hid_device_info* host_mcu_ite = host_mcu_devs;
+
+        for (; host_mcu_ite != NULL; host_mcu_ite = host_mcu_ite->next)
+        {
+            if (host_mcu_ite->path == NULL)
+            {
+                // Board already used or failed to get parent.
+                continue;
+            }
+
+            DEVINST host_mcu_parent_node;
+            result = tk_ctp_board_int_hid_locate_parent_dev_node_by_dev_path(&host_mcu_parent_node, host_mcu_ite->path, TK_CTP_BOARD_HUB_VID, TK_CTP_BOARD_HUB_PID);
+
+            if (!result)
+            {
+                // Do not try again.
+                free(host_mcu_ite->path);
+                host_mcu_ite->path = NULL;
+            }
+            else if (nedbg_parent_node == host_mcu_parent_node)
+            {
+                // Match! :)
+                break;
+            }
+            else
+            {
+            }
+        }
+
+        if (host_mcu_ite == NULL)
+        {
+            tk_api_log_int_error("tk_ctp_board_enumerate: could not match Host MCU for nEDBG: %s", nedbg_ite->path);
+            continue;
+        }
+
+        if (host_mcu_ite->path == NULL)
+        {
+            tk_api_log_int_error("tk_ctp_board_enumerate: host mcu without path, how did we get match with nEDBG: %s ?", nedbg_ite->path);
+            continue;
+        }
+
+        struct tk_ctp_board_info* new_board = (struct tk_ctp_board_info*)malloc(sizeof(struct tk_ctp_board_info));
+
+        if (new_board == NULL)
+        {
+            tk_api_log_int_error("tk_ctp_board_enumerate: board allocation failed");
+            break;
+        }
+
+        new_board->nedbg_serial_number = nedbg_ite->serial_number;
+        nedbg_ite->serial_number = NULL;
+
+        new_board->nedbg_path = nedbg_ite->path;
+        nedbg_ite->path = NULL;
+
+        new_board->host_mcu_path = host_mcu_ite->path;
+        host_mcu_ite->path = NULL;
+
+        new_board->next = NULL;
+
+        *boards_ite = new_board;
+        boards_ite = &new_board->next;
+    }
+
+    hid_free_enumeration(host_mcu_devs);
+    hid_free_enumeration(nedbg_devs);
+
+    if (boards == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_enumerate: No CryptoAuth Trust Platform boards found");
+    }
+
+    return boards;
+}
+
+struct tk_ctp_board_info TK_API_EXPORT * TK_API_CALL tk_ctp_board_next_board(struct tk_ctp_board_info* boards)
+{
+    tk_api_log_int_clear();
+
+    if (boards == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_next_board: null board");
+        return NULL;
+    }
+
+    return boards->next;
+}
+
+void TK_API_EXPORT TK_API_CALL tk_ctp_board_free_enumeration(struct tk_ctp_board_info* boards)
+{
+    tk_api_log_int_clear();
+
+    struct tk_ctp_board_info* b = boards;
+    while (b)
+    {
+        free(b->nedbg_serial_number);
+        free(b->nedbg_path);
+        free(b->host_mcu_path);
+        b = b->next;
+    }
+}
+
+const wchar_t TK_API_EXPORT * TK_API_CALL tk_ctp_board_get_nedbg_serial_number(struct tk_ctp_board_info* board)
+{
+    tk_api_log_int_clear();
+
+    if (board == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_get_nedbg_serial_number: null board");
+        return NULL;
+    }
+
+    return board->nedbg_serial_number;
+}
+
+const char TK_API_EXPORT * TK_API_CALL tk_ctp_board_get_nedbg_path(struct tk_ctp_board_info* board)
+{
+    tk_api_log_int_clear();
+
+    if (board == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_get_nedbg_path: null board");
+        return NULL;
+    }
+
+    return board->nedbg_path;
+}
+
+const char TK_API_EXPORT * TK_API_CALL tk_ctp_board_get_host_mcu_path(struct tk_ctp_board_info* board)
+{
+    tk_api_log_int_clear();
+
+    if (board == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_get_host_mcu_path: null board");
+        return NULL;
+    }
+
+    return board->host_mcu_path;
+}
+
+static wchar_t* tk_ctp_board_int_str_to_wstr(const char* str)
+{
+    if (str == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_str_to_wstr: invalid argument");
+        return NULL;
+    }
+
+    size_t wstr_len = mbstowcs(NULL, str, INT_MAX);
+    wchar_t* wstr = (wchar_t*)calloc(wstr_len + 1U, sizeof(wchar_t));
+
+    if (wstr == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_str_to_wstr: calloc failed");
+        return NULL;
+    }
+
+    size_t chars_converted = mbstowcs(wstr, str, wstr_len);
+
+    if (chars_converted > wstr_len)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_str_to_wstr: buffer too small for %d chars", chars_converted);
+        free(wstr);
+        return NULL;
+    }
+
+    wstr[chars_converted] = L'\0';
+
+    return wstr;
+}
+
+static void* tk_ctp_board_int_hid_get_device_interface_property(const char* interface_path, const DEVPROPKEY* property_key, DEVPROPTYPE expected_property_type)
+{
+    if (interface_path == NULL || property_key == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_get_device_interface_property: invalid arguments");
+        return NULL;
+    }
+
+    wchar_t* wpath = tk_ctp_board_int_str_to_wstr(interface_path);
+
+    if (wpath == NULL)
+    {
+        return NULL;
+    }
+
+    PBYTE property_value = NULL;
+    ULONG len = 0;
+    DEVPROPTYPE property_type;
+    CONFIGRET cr = CM_Get_Device_Interface_PropertyW(wpath, property_key, &property_type, NULL, &len, 0);
+
+    if (cr != CR_BUFFER_SMALL || property_type != expected_property_type)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_get_device_interface_property: failed with cr: %d, prop: %d, expected prop: %d for %s", cr, property_type, expected_property_type, interface_path);
+        goto error;
+    }
+
+    property_value = (PBYTE)calloc(len, sizeof(BYTE));
+
+    if (property_value == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_get_device_interface_property: calloc failed");
+        goto error;
+    }
+
+    cr = CM_Get_Device_Interface_PropertyW(wpath, property_key, &property_type, property_value, &len, 0);
+
+    if (cr != CR_SUCCESS)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_get_device_interface_property: failed with cr: %d for %s", cr, interface_path);
+        free(property_value);
+        property_value = NULL;
+        goto error;
+    }
+
+error:
+    free(wpath);
+    return property_value;
+}
+
+static void* tk_ctp_board_int_hid_get_devnode_property(DEVINST dev_node, const DEVPROPKEY* property_key, DEVPROPTYPE expected_property_type)
+{
+    if (property_key == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_get_devnode_property: invalid argument");
+        return NULL;
+    }
+
+    ULONG len = 0;
+    DEVPROPTYPE property_type;
+    CONFIGRET cr = CM_Get_DevNode_PropertyW(dev_node, property_key, &property_type, NULL, &len, 0);
+
+    if (cr != CR_BUFFER_SMALL || property_type != expected_property_type)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_get_devnode_property: failed with cr: %d, prop: %d, expected prop: %d for %d", cr, property_type, expected_property_type, dev_node);
+        return NULL;
+    }
+
+    PBYTE property_value = (PBYTE)calloc(len, sizeof(BYTE));
+
+    if (property_value == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_get_devnode_property: calloc failed");
+        return NULL;
+    }
+
+    cr = CM_Get_DevNode_PropertyW(dev_node, property_key, &property_type, property_value, &len, 0);
+
+    if (cr != CR_SUCCESS)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_get_devnode_property: failed with cr: %d for %d", cr, dev_node);
+        free(property_value);
+        property_value = NULL;
+    }
+
+    return property_value;
+}
+
+static bool tk_ctp_board_int_hid_locate_dev_node(DEVINST* dev_node, const char* interface_path)
+{
+    if (dev_node == NULL || interface_path == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_locate_dev_node: invalid arguments");
+        return false;
+    }
+
+    bool result = false;
+    wchar_t* device_id = (wchar_t*)tk_ctp_board_int_hid_get_device_interface_property(interface_path, &DEVPKEY_Device_InstanceId, DEVPROP_TYPE_STRING);
+
+    if (device_id != NULL)
+    {
+            CONFIGRET cr = CM_Locate_DevNodeW(dev_node, (DEVINSTID_W)device_id, CM_LOCATE_DEVNODE_NORMAL);
+
+            if (cr != CR_SUCCESS)
+            {
+                tk_api_log_int_error("tk_ctp_board_int_hid_locate_dev_node: failed to get device node id, cr: %d for %s, ", cr, interface_path);
+            }
+            else
+            {
+                result = true;
+            }
+    }
+
+    free(device_id);
+
+    return result;
+}
+
+static bool tk_ctp_board_int_hid_locate_parent_dev_node(DEVINST* parent_dev_node, DEVINST dev_node, unsigned short vendor_id, unsigned short product_id)
+{
+    if (parent_dev_node == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_locate_parent_dev_node: invalid argument");
+        return false;
+    }
+
+    // See: https://learn.microsoft.com/en-us/windows-hardware/drivers/install/standard-usb-identifiers#single-interface-usb-devices
+    wchar_t hardware_id_subpart[] = L"USB\\VID_xxxx&PID_xxxx";
+    (void)_snwprintf(hardware_id_subpart, sizeof(hardware_id_subpart) / sizeof(hardware_id_subpart[0]), L"USB\\VID_%04x&PID_%04x", vendor_id, product_id);
+    hardware_id_subpart[sizeof(hardware_id_subpart) / sizeof(hardware_id_subpart[0]) - 1U] = L'\0';
+
+    DEVINST parent_node = dev_node;
+    bool result = false;
+
+    while (!result)
+    {
+        CONFIGRET cr = CM_Get_Parent(&parent_node, parent_node, 0);
+
+        if (cr != CR_SUCCESS)
+        {
+            tk_api_log_int_error("tk_ctp_board_int_hid_locate_parent_dev_node: failed with cr: %d for %d", cr, dev_node);
+            break;
+        }
+
+        wchar_t* hardware_ids = (wchar_t*)tk_ctp_board_int_hid_get_devnode_property(parent_node, &DEVPKEY_Device_HardwareIds, DEVPROP_TYPE_STRING_LIST);
+
+        if (hardware_ids == NULL)
+        {
+            // Not found, error should be already logged.
+            break;
+        }
+
+        if (wcsstr(hardware_ids, hardware_id_subpart) != NULL)
+        {
+            // Got it! :)
+            result = true;
+            *parent_dev_node = parent_node;
+        }
+
+        free(hardware_ids);
+    }
+
+    return result;
+}
+
+static bool tk_ctp_board_int_hid_locate_parent_dev_node_by_dev_path(DEVINST* parent_dev_node, const char* interface_path, unsigned short vendor_id, unsigned short product_id)
+{
+    if (parent_dev_node == NULL || interface_path == NULL)
+    {
+        tk_api_log_int_error("tk_ctp_board_int_hid_locate_parent_dev_node_by_dev_path: invalid arguments");
+        return false;
+    }
+
+    DEVINST dev_node;
+    bool result = tk_ctp_board_int_hid_locate_dev_node(&dev_node, interface_path);
+
+    if (result)
+    {
+        DEVINST parent_node;
+        result = tk_ctp_board_int_hid_locate_parent_dev_node(&parent_node, dev_node, vendor_id, product_id);
+
+        if (result)
+        {
+            *parent_dev_node = parent_node;
+        }
+    }
+
+    return result;
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/toolkit/src/toolkit/windows/tk_ctp_board.c
+++ b/toolkit/src/toolkit/windows/tk_ctp_board.c
@@ -270,14 +270,15 @@ static void* tk_ctp_board_int_hid_get_device_interface_property(const char* inte
     if (cr != CR_SUCCESS)
     {
         tk_api_log_int_error("tk_ctp_board_int_hid_get_device_interface_property: failed with cr: %d for %s", cr, interface_path);
-        free(property_value);
-        property_value = NULL;
         goto error;
     }
 
-error:
-    free(wpath);
     return property_value;
+
+error:
+    free(property_value);
+    free(wpath);
+    return NULL;
 }
 
 static void* tk_ctp_board_int_hid_get_devnode_property(DEVINST dev_node, const DEVPROPKEY* property_key, DEVPROPTYPE expected_property_type)


### PR DESCRIPTION
# Description
This delivery contains changes that allow a user to create multiple HID device instances based on the device path. 

There is also a mechanism for enumerating all CryptoAuth Trust Platform boards attached to the host PC. The board description contains:
- Serial number of nEDBG embedded on the board. This serial number matches the serial number that is on the physical sticker on the board.
- Path to the nEDBG
- Path to the Host MCU.

See [CryptoAuth Trust Platform board documentation](https://ww1.microchip.com/downloads/aemDocuments/documents/SCBU/ProductDocuments/UserGuides/CryptoAuth-Trust-Platform-User%27s-Guide-DS50002921B.pdf
) for connection details. 

# Checklist
* [x] I have reviewed the [CONTRIBUTING.md](https://github.com/MicrochipTech/cryptoauthlib/blob/main/CONTRIBUTING.md) and agree to it's terms
